### PR TITLE
Adding Pipetools option to _not_ write JSON files

### DIFF
--- a/pipetools/__init__.py
+++ b/pipetools/__init__.py
@@ -26,7 +26,8 @@ def mkdir(path):
         os.makedirs(path)
 
 
-def get(base_url, token, outdir=".", path="users", sub_path="", limit=100, stdout=False, ids=[], params={}, silent=False):
+def get(base_url, token, outdir=".", path="users", sub_path="", limit=100,
+        stdout=False, ids=[], params={}, silent=False, no_output=False):
     collected_ids = []
 
     if len(ids)==0:
@@ -100,8 +101,9 @@ def get(base_url, token, outdir=".", path="users", sub_path="", limit=100, stdou
     if stdout:
         print(json.dumps(data, indent=4, sort_keys=True, ensure_ascii=False))
     else:
-        with open(os.path.join(outdir, f"{path}.json"), "w") as out_file:
-            json.dump(data, out_file, indent=4, sort_keys=True)
+        if not no_output:
+            with open(os.path.join(outdir, f"{path}.json"), "w") as out_file:
+                json.dump(data, out_file, indent=4, sort_keys=True)
     return data
 
 


### PR DESCRIPTION
Our internal tools heavily depend upon Pipetools. However, Pipetools by design writes JSON files into the current working directory (or writes to stdout). This results in higher-level tools not requiring the JSON files (using the JSON directly as object) dripping JSON files wherever executed.

This PR adds an option to `pipetools.get(...)` to not write files.